### PR TITLE
Add content headers to putObject request

### DIFF
--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -135,9 +135,12 @@ class S3StorageConnector implements StorageConnectorInterface {
 		if ( $meta['contains_db'] ) {
 			$client->putObject(
 				[
-					'Bucket'     => $this->get_bucket_name( $repository ),
-					'Key'        => $meta['project'] . '/' . $id . '/data.sql.gz',
-					'SourceFile' => realpath( $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ) ),
+					'Bucket'          => $this->get_bucket_name( $repository ),
+					'Key'             => $meta['project'] . '/' . $id . '/data.sql.gz',
+					'SourceFile'      => realpath( $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ) ),
+					'ContentEncoding' => 'gzip',
+					'ContentMD5'      => base64_encode( md5_file( $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ), true ) ), // phpcs:ignore
+					'ContentType'     => 'application/x-gzip',
 				]
 			);
 		}
@@ -145,9 +148,12 @@ class S3StorageConnector implements StorageConnectorInterface {
 		if ( $meta['contains_files'] ) {
 			$client->putObject(
 				[
-					'Bucket'     => $this->get_bucket_name( $repository ),
-					'Key'        => $meta['project'] . '/' . $id . '/files.tar.gz',
-					'SourceFile' => realpath( $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ) ),
+					'Bucket'          => $this->get_bucket_name( $repository ),
+					'Key'             => $meta['project'] . '/' . $id . '/files.tar.gz',
+					'SourceFile'      => realpath( $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ) ),
+					'ContentEncoding' => 'gzip',
+					'ContentMD5'      => base64_encode( md5_file( $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ), true ) ), // phpcs:ignore
+					'ContentType'     => 'application/x-gzip',
 				]
 			);
 		}


### PR DESCRIPTION
This fixes the following issue I encountered when pushing snapshots locally:

```
Error: Error executing "PutObject" on "[http://wpsnapshots-10up.s3.us-west-1.amazonaws.com/wcg-2023/3740485b33e4e41da4a800d120801d00/files.tar.gz](http://wpsnapshots-10up.s3.us-west-1.amazonaws.com/wcg-2023/3740485b33e4e41da4a800d120801d00/files.tar.gz)"; AWS HTTP error: Client error: `PUT <http://wpsnapshots-10up.s3.us-west-1.amazonaws.com/wcg-2023/3740485b33e4e41da4a800d120801d00/files.tar.gz`> resulted in a `400 Bad Request` response:
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>XAmzContentSHA256Mismatch</Code><Message>The provided 'x-amz-content (truncated...)
XAmzContentSHA256Mismatch (client): The provided 'x-amz-content-sha256' header does not match what was computed. - <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>XAmzContentSHA256Mismatch</Code><Message>The provided 'x-amz-content-sha256' header does not match what was computed.</Message><ClientComputedContentSHA256>505535e2ea7b54483c78889d29032384cf6b8d3987bd4b5e2f5bdfc45bd63394</ClientComputedContentSHA256><S3ComputedContentSHA256>90b81650cc424a19f92f41212d4b4c15e33ec090141460ec637f91647cf959cf</S3ComputedContentSHA256><RequestId>2NZ9FPJ920374PVS</RequestId><HostId>Q79JUJayXgn+TEVO+QTHhjoj9NCV+bV3qaTwbJlymcaccvHgyJcz1/3VUFrdHwH9UUyGTxOE+t0=</HostId></Error>
```

See https://github.com/aws/aws-sdk-go/issues/148

