### PR TITLE
Search-replace updates

### DIFF
--- a/includes/classes/WPCLICommands/Pull/URLReplacer.php
+++ b/includes/classes/WPCLICommands/Pull/URLReplacer.php
@@ -139,7 +139,7 @@ abstract class URLReplacer {
 	 * @param bool   $multisite Whether to run multisite search and replace.
 	 */
 	protected function run_search_and_replace( string $search, string $replace, array $tables_to_update, bool $multisite = false ) : void {
-		$command = 'search-replace ' . $search . ' ' . $replace . ' ' . implode( ' ', $tables_to_update ) . ' --skip-columns=guid --precise --skip-themes --skip-plugins --skip-packages';
+		$command = 'search-replace ' . $search . ' ' . $replace . ' ' . implode( ' ', $tables_to_update ) . ' --precise --skip-themes --skip-plugins --skip-packages';
 
 		if ( $multisite ) {
 			$command .= ' --network';

--- a/tests/php/includes/WPCLICommands/Pull/TestMultisiteURLReplacer.php
+++ b/tests/php/includes/WPCLICommands/Pull/TestMultisiteURLReplacer.php
@@ -138,7 +138,7 @@ class TestMultisiteURLReplacer extends TestCase {
 			2,
 			[
 				[
-					'search-replace http://home-url.com readline0 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --skip-columns=guid --precise --skip-themes --skip-plugins --skip-packages --network',
+					'search-replace //home-url.com readline0 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --precise --skip-themes --skip-plugins --skip-packages --network',
 					[
 						'launch' => true,
 						'exit_error' => false,
@@ -146,7 +146,7 @@ class TestMultisiteURLReplacer extends TestCase {
 					],
 				],
 				[
-					'search-replace http://site-url.com readline1 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --skip-columns=guid --precise --skip-themes --skip-plugins --skip-packages --network',
+					'search-replace //site-url.com readline1 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --precise --skip-themes --skip-plugins --skip-packages --network',
 					[
 						'launch' => true,
 						'exit_error' => false,

--- a/tests/php/includes/WPCLICommands/Pull/TestSingleSiteURLReplacer.php
+++ b/tests/php/includes/WPCLICommands/Pull/TestSingleSiteURLReplacer.php
@@ -97,7 +97,7 @@ class TestSingleSiteURLReplacer extends TestCase {
 			1,
 			[
 				[
-					'search-replace http://search.com http://replace.com table1 table2 --skip-columns=guid --precise --skip-themes --skip-plugins --skip-packages',
+					'search-replace http://search.com http://replace.com table1 table2 --precise --skip-themes --skip-plugins --skip-packages',
 					[
 						'launch' => true,
 						'exit_error' => false,
@@ -131,7 +131,7 @@ class TestSingleSiteURLReplacer extends TestCase {
 			2,
 			[
 				[
-					'search-replace http://home-url.com readline2 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --skip-columns=guid --precise --skip-themes --skip-plugins --skip-packages',
+					'search-replace http://home-url.com readline2 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --precise --skip-themes --skip-plugins --skip-packages',
 					[
 						'launch' => true,
 						'exit_error' => false,
@@ -139,7 +139,7 @@ class TestSingleSiteURLReplacer extends TestCase {
 					],
 				],
 				[
-					'search-replace http://site-url.com readline3 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --skip-columns=guid --precise --skip-themes --skip-plugins --skip-packages',
+					'search-replace http://site-url.com readline3 wp_commentmeta wp_comments wp_links wp_options wp_postmeta wp_posts wp_termmeta wp_usermeta wp_users --precise --skip-themes --skip-plugins --skip-packages',
 					[
 						'launch' => true,
 						'exit_error' => false,


### PR DESCRIPTION
Fixes #27 

I don't know why `wp_update_site` wasn't working, so I copied the direct SQL command from the old repo.

Additionally, for some of my own sites I was finding that some of the URLs were not being replaced due to URL scheme mismatches, so I removed https:/http: from the URLs before running the search-replace command.