### PR TITLE
Update create-repository args

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ __wp snapshots create-repository <repository>__
 ```
   <repository>
     The repository to create
+
+  [--region=<region>]
+    The region to create the repository in
+    ---
+    default: us-west-1
+    ---
+
+  [--profile=<profile>]
+    The AWS profile to use
+    ---
+    default: default
+    ---
 ```
 </details>
 
@@ -141,7 +153,7 @@ __wp snapshots push [--repository=\<repository\>] [--exclude=\<exclude\>] [--slu
 <summary>Show Arguments</summary>
 
 ```
-  [--repository=\<repository\>]
+  [--repository=<repository>]
     Repository to use.
     ---
     default: 10up
@@ -333,7 +345,7 @@ __wp snapshots delete <snapshot_id> [--repository=\<repository\>]__
   <snapshot_id>
     Snapshot ID to pull.
 
-  [--repository=\<repository\>]
+  [--repository=<repository>]
     Repository to use.
 
 ```

--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -211,8 +211,10 @@ class DynamoDBConnector implements DBConnectorInterface {
 	 * @return DynamoDbClient
 	 */
 	private function get_client( string $profile, string $region ) : DynamoDbClient {
-		if ( ! isset( $this->clients[ $region ] ) ) {
-			$this->clients[ $region ] = new DynamoDbClient(
+		$client_key = $profile . '_' . $region;
+
+		if ( ! isset( $this->clients[ $client_key ] ) ) {
+			$this->clients[ $client_key ] = new DynamoDbClient(
 				[
 					'region'  => $region,
 					'profile' => $profile,
@@ -222,6 +224,6 @@ class DynamoDBConnector implements DBConnectorInterface {
 			);
 		}
 
-		return $this->clients[ $region ];
+		return $this->clients[ $client_key ];
 	}
 }

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -231,8 +231,10 @@ class S3StorageConnector implements StorageConnectorInterface {
 	 * @return S3Client
 	 */
 	private function get_client( string $profile, string $region ) : S3Client {
-		if ( ! isset( $this->clients[ $region ] ) ) {
-			$this->clients[ $region ] = new S3Client(
+		$client_key = $profile . '_' . $region;
+
+		if ( ! isset( $this->clients[ $client_key ] ) ) {
+			$this->clients[ $client_key ] = new S3Client(
 				[
 					'region'    => $region,
 					'profile'   => $profile,
@@ -243,7 +245,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 			);
 		}
 
-		return $this->clients[ $region ];
+		return $this->clients[ $client_key ];
 	}
 
 	/**

--- a/includes/classes/WPCLICommands/CreateRepository.php
+++ b/includes/classes/WPCLICommands/CreateRepository.php
@@ -31,8 +31,8 @@ final class CreateRepository extends WPCLICommand {
 			$this->set_assoc_args( $assoc_args );
 
 			$repository_name = $this->get_repository_name( true, 0 );
-			$region          = $this->get_region();
-			$profile         = $this->get_profile_for_repository();
+			$region          = $this->get_assoc_arg( 'region' );
+			$profile         = $this->get_assoc_arg( 'profile' );
 
 			$this->storage_connector->create_bucket( $profile, $repository_name, $region );
 			$this->db_connector->create_tables( $profile, $repository_name, $region );
@@ -66,6 +66,20 @@ final class CreateRepository extends WPCLICommand {
 					'name'        => 'repository',
 					'description' => 'The repository to create',
 					'optional'    => false,
+				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'region',
+					'description' => 'The region to create the repository in',
+					'optional'    => true,
+					'default'     => 'us-west-1',
+				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'profile',
+					'description' => 'The AWS profile to use',
+					'optional'    => true,
+					'default'     => 'default',
 				],
 			],
 			'when'      => 'before_wp_load',

--- a/tests/php/includes/Snapshots/TestDBConnector.php
+++ b/tests/php/includes/Snapshots/TestDBConnector.php
@@ -71,7 +71,7 @@ class TestDBConnector extends TestCase {
 		$client->method( 'getIterator' )->willReturn( [] );
 
 		// Set client as private property.
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		// Assert that client's getIterator method was called with expected args.
 		$client->expects( $this->once() )->method( 'getIterator' )->with(
@@ -110,7 +110,7 @@ class TestDBConnector extends TestCase {
 		$client->method( 'getItem' )->willReturn( [] );
 
 		// Set client as private property.
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		// Assert that client's getItem method was called with expected args.
 		$client->expects( $this->once() )->method( 'getItem' )->with(
@@ -143,7 +143,7 @@ class TestDBConnector extends TestCase {
 		$client->method( 'waitUntil' )->willReturn( [] );
 
 		// Set client as private property.
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		// Assert that client's createTable method was called with expected args.
 		$client->expects( $this->once() )->method( 'createTable' )->with(

--- a/tests/php/includes/Snapshots/TestS3StorageConnector.php
+++ b/tests/php/includes/Snapshots/TestS3StorageConnector.php
@@ -77,7 +77,7 @@ class TestS3StorageConnector extends TestCase {
 				'SaveAs' => '/tenup-snapshots-tmp/test-id/data.sql.gz',
 			] );
 
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		$this->connector->download_snapshot(
 			'test-id',
@@ -107,7 +107,7 @@ class TestS3StorageConnector extends TestCase {
 				'SaveAs' => '/tenup-snapshots-tmp/test-id/files.tar.gz',
 			] );
 
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		$this->connector->download_snapshot(
 			'test-id',
@@ -148,7 +148,7 @@ class TestS3StorageConnector extends TestCase {
 				]
 			);
 
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		$this->connector->download_snapshot(
 			'test-id',
@@ -178,7 +178,7 @@ class TestS3StorageConnector extends TestCase {
 				'LocationConstraint' => 'test-region',
 			] );
 
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		$this->connector->create_bucket( 'default', 'test-repo', 'test-region' );
 	}
@@ -197,7 +197,7 @@ class TestS3StorageConnector extends TestCase {
 		$client->expects( $this->never() )
 			->method( 'createBucket' );
 
-		$this->set_private_property( $this->connector, 'clients', [ 'test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
 		$this->expectException( SnapshotsException::class );
 		$this->expectExceptionMessage( 'S3 bucket already exists.' );


### PR DESCRIPTION
Closes #35 

Updates the create-repository command to use the default AWS credentials unless overridden with a --profile associative arg.

Also preemptively fixed what may have turned into a bug later with the keys used for clients stored in object state.