### PR TITLE
Force use of direct FS

### DIFF
--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -36,6 +36,13 @@ class FileSystem implements SharedService {
 		if ( ! $this->wp_filesystem ) {
 			if ( ! $wp_filesystem ) {
 				if ( function_exists( 'WP_Filesystem' ) ) {
+					add_filter(
+						'filesystem_method',
+						static function () {
+							return 'direct';
+						},
+						PHP_INT_MAX
+					);
 					WP_Filesystem( false, false, true );
 
 				} else {


### PR DESCRIPTION
It's possible for mu-plugins in a local environment to filter which filesystem class is used, which can completely prevent this package from working. This forces the direct filesystem method to be used. 