### PR TITLE
Use gunzip to unzip file

### DIFF
--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -11,6 +11,8 @@ use TenUp\Snapshots\Exceptions\SnapshotsException;
 use TenUp\Snapshots\Infrastructure\SharedService;
 use WP_Filesystem_Base;
 
+use function TenUp\Snapshots\Utils\snapshots_add_trailing_slash;
+
 /**
  * SnapshotsDirectory class.
  *
@@ -129,8 +131,8 @@ class FileSystem implements SharedService {
 
 		if ( is_wp_error( $result ) && 'incompatible_archive' === $result->get_error_code() && strpos( $file, '.sql.gz' ) !== false ) {
 			// Unzip with gzip.
-			$unzip_gzip = sprintf( 'gunzip -c %s > %s', escapeshellarg( $file ), escapeshellarg( $destination . basename( $file, '.gz' ) ) );
-			$result     = exec( $unzip_gzip );
+			$unzip_gzip = sprintf( 'gunzip -c %s > %s', escapeshellarg( $file ), escapeshellarg( snapshots_add_trailing_slash( $destination ) . basename( $file, '.gz' ) ) );
+			$result     = exec( $unzip_gzip ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 
 			if ( false === $result ) {
 				throw new SnapshotsException( 'Unable to unzip file.' );


### PR DESCRIPTION
The PHP gz* functions were failing with very large zip files, so this unzips it with a shell command instead.