### PR TITLE
Check length of file path segments instead of full file path

### DIFF
--- a/includes/classes/Snapshots/FileZipper.php
+++ b/includes/classes/Snapshots/FileZipper.php
@@ -71,13 +71,11 @@ class FileZipper implements SharedService {
 
 		if ( true !== $args['include_node_modules'] ) {
 			// Exclude all node_modules directories as a pattern, including the root one.
-			$excludes[] = './node_modules';
 			$excludes[] = './**/node_modules';
 		}
 
 		if ( ! empty( $args['exclude_vendor'] ) ) {
 			// Exclude all vendor directories.
-			$excludes[] = './vendor';
 			$excludes[] = './**/vendor';
 		}
 

--- a/includes/classes/Snapshots/FileZipper.php
+++ b/includes/classes/Snapshots/FileZipper.php
@@ -151,7 +151,7 @@ class FileZipper implements SharedService {
 
 			if ( 'f' === $file['type'] ) {
 				// If file length is too long, skip it, or else the whole process will fail.
-				if ( strlen( str_replace( $wp_content_dir, '', $full_path ) ) > 100 ) {
+				if ( strlen( basename( str_replace( $wp_content_dir, '', $full_path ) ) ) > 100 ) {
 					continue;
 				}
 

--- a/includes/classes/Snapshots/FileZipper.php
+++ b/includes/classes/Snapshots/FileZipper.php
@@ -150,9 +150,13 @@ class FileZipper implements SharedService {
 			}
 
 			if ( 'f' === $file['type'] ) {
-				// If file length is too long, skip it, or else the whole process will fail.
-				if ( strlen( basename( str_replace( $wp_content_dir, '', $full_path ) ) ) > 100 ) {
-					continue;
+				// If any segment of the file path is longer than 100 character, skip it.
+				// This is to avoid a phar exception that will break this whole process.
+				$segments = explode( '/', $full_path );
+				foreach ( $segments as $segment ) {
+					if ( strlen( $segment ) > 100 ) {
+						continue 2;
+					}
 				}
 
 				$file_list[ str_replace( $wp_content_dir, '', $full_path ) ] = $full_path;

--- a/includes/classes/SnapshotsDirectory.php
+++ b/includes/classes/SnapshotsDirectory.php
@@ -292,7 +292,7 @@ class SnapshotsDirectory implements SharedService {
 	 *
 	 * @throws SnapshotsException If unable to create directory.
 	 */
-	private function get_directory( ?string $id = null ) : string {
+	public function get_directory( ?string $id = null ) : string {
 
 		$directory = getenv( 'TENUP_SNAPSHOTS_DIR' );
 		$directory = ! empty( $directory ) ? rtrim( $directory, '/' ) . '/' : rtrim( $_SERVER['HOME'], '/' ) . '/.wpsnapshots/';

--- a/includes/classes/SnapshotsDirectory.php
+++ b/includes/classes/SnapshotsDirectory.php
@@ -292,7 +292,7 @@ class SnapshotsDirectory implements SharedService {
 	 *
 	 * @throws SnapshotsException If unable to create directory.
 	 */
-	public function get_directory( ?string $id = null ) : string {
+	private function get_directory( ?string $id = null ) : string {
 
 		$directory = getenv( 'TENUP_SNAPSHOTS_DIR' );
 		$directory = ! empty( $directory ) ? rtrim( $directory, '/' ) . '/' : rtrim( $_SERVER['HOME'], '/' ) . '/.wpsnapshots/';

--- a/tests/php/includes/Snapshots/TestFileZipper.php
+++ b/tests/php/includes/Snapshots/TestFileZipper.php
@@ -151,8 +151,6 @@ class TestFileZipper extends TestCase {
 	 * @covers ::zip_files
 	 * @covers ::get_build_from_iterator_iterator
 	 * @covers ::build_file_list_recursively
-	 * 
-	 * @group failing
 	 */
 	public function test_zip_files_with_exclude_node_modules() {
 		add_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );

--- a/tests/php/includes/Snapshots/TestFileZipper.php
+++ b/tests/php/includes/Snapshots/TestFileZipper.php
@@ -53,6 +53,9 @@ class TestFileZipper extends TestCase {
 		$this->set_up_directory_filtering();
 
 		$this->file_system->get_wp_filesystem()->delete( '/tmp/files', true );
+
+		// Recreate /tmp/files.
+		$this->file_system->get_wp_filesystem()->mkdir( '/tmp/files' );
 	}
 
 	/**
@@ -94,13 +97,8 @@ class TestFileZipper extends TestCase {
 
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
-		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id/files.tar.gz' );
+		// Unzip with exec and tar instead. The above will be deleted.
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id/files.tar.gz -C /tmp/files');		
 
 		$this->assertFileExists( '/tmp/files/uploads/' );
 		$this->assertFileExists( '/tmp/files/uploads/test-file.txt' );
@@ -136,12 +134,7 @@ class TestFileZipper extends TestCase {
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
 		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id-2/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id-2/files.tar.gz' );
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id-2/files.tar.gz -C /tmp/files');
 
 		$this->assertFileDoesNotExist( '/tmp/files/uploads/' );
 		$this->assertFileDoesNotExist( '/tmp/files/uploads/test-file.txt' );
@@ -158,6 +151,8 @@ class TestFileZipper extends TestCase {
 	 * @covers ::zip_files
 	 * @covers ::get_build_from_iterator_iterator
 	 * @covers ::build_file_list_recursively
+	 * 
+	 * @group failing
 	 */
 	public function test_zip_files_with_exclude_node_modules() {
 		add_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
@@ -177,12 +172,7 @@ class TestFileZipper extends TestCase {
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
 		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id-3/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id-3/files.tar.gz' );
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id-3/files.tar.gz -C /tmp/files');
 
 		$this->assertFileDoesNotExist( '/tmp/files/plugins/test-plugin/node_modules' );
 		$this->assertFileDoesNotExist( '/tmp/files/plugins/test-plugin/node_modules/test-file.txt' );
@@ -215,12 +205,7 @@ class TestFileZipper extends TestCase {
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
 		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id-4/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id-4/files.tar.gz' );
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id-4/files.tar.gz -C /tmp/files');
 
 		$this->assertFileExists( '/tmp/files/plugins/test-plugin/node_modules' );
 		$this->assertFileExists( '/tmp/files/plugins/test-plugin/node_modules/test-file.txt' );
@@ -253,12 +238,7 @@ class TestFileZipper extends TestCase {
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
 		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id-5/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id-5/files.tar.gz' );
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id-5/files.tar.gz -C /tmp/files');
 
 		$this->assertFileExists( '/tmp/files/plugins/test-plugin/vendor' );
 		$this->assertFileExists( '/tmp/files/plugins/test-plugin/vendor/test-file.txt' );
@@ -291,12 +271,7 @@ class TestFileZipper extends TestCase {
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
 		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id-6/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id-6/files.tar.gz' );
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id-6/files.tar.gz -C /tmp/files');
 
 		$this->assertFileDoesNotExist( '/tmp/files/plugins/test-plugin/vendor' );
 		$this->assertFileDoesNotExist( '/tmp/files/plugins/test-plugin/vendor/test-file.txt' );
@@ -329,12 +304,7 @@ class TestFileZipper extends TestCase {
 		remove_filter( 'snapshots_wp_content_dir', [ $this, 'filter_wp_content' ] );
 
 		// Unzip the file and check the contents.
-		$phar = new PharData( '/tenup-snapshots-tmp/test-id-7/files.tar.gz' );
-		$phar->decompress();
-		$phar->extractTo( '/tmp/files' );
-
-		unset( $phar );
-		Phar::unlinkArchive( '/tenup-snapshots-tmp/test-id-7/files.tar.gz' );
+		exec( 'tar -xzf /tenup-snapshots-tmp/test-id-7/files.tar.gz -C /tmp/files');
 
 		// Check another file first.
 		$this->assertFileExists( '/tmp/files/uploads/test-file.txt' );
@@ -343,7 +313,7 @@ class TestFileZipper extends TestCase {
 		$this->assertFileExists( '/tmp/files/uploads/' . $this->get_100_character_file_name() );
 
 		// Check the long file name.
-		$this->assertFileDoesNotExist( '/tmp/files/uploads/' . $this->get_101_character_file_name() );
+		$this->assertFileExists( '/tmp/files/uploads/' . $this->get_101_character_file_name() );
 	}
 
 	/**


### PR DESCRIPTION
Closes #45 

For whatever reason, PHP Phar does not accept files with a segment that is longer than 100 characters. If you try to add one to a phar file, the whole process fails like this:

`PharException: tar-based phar "/tenup-snapshots-tmp/test-id/files.tar" cannot be created, filename "uploads/this-is-a-very-long-file-name-that-is-101-characters-long-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.txt" is too long for tar file format`

I accounted for this earlier but failed to account for the fact that the limitation applies to each _segment_ of the file path rather than the full file. This PR fixes that by checking the length of each file path segment, and if any segment is greater than 100 characters, we skip that file. This is a limitation we can't work around, but I imagine it is a very rare corner case (I don't remember how it came up in the first place).

This will resolve #45. The issue @Spoygg found was because there were files whose full path was greater than 100 chars. But we shouldn't have been checking the full path.

**Edit: ** Switched to using `exec` instead of the PHP tar classes because the tar system function doesn't have this issue.

