### PR TITLE
Restore support for env vars

### DIFF
--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -213,15 +213,21 @@ class DynamoDBConnector implements DBConnectorInterface {
 	private function get_client( string $profile, string $region ) : DynamoDbClient {
 		$client_key = $profile . '_' . $region;
 
+		$args = [
+			'region'  => $region,
+			'profile' => $profile,
+			'version' => '2012-08-10',
+			'csm'     => false,
+		];
+
+		// Check if the necessary AWS env vars are set; if so, the profile arg is not needed.
+		// These are the same env vars the SDK checks for in CredentialProvider.php.
+		if ( getenv( 'AWS_ACCESS_KEY_ID' ) && getenv( 'AWS_SECRET_ACCESS_KEY' ) ) {
+			unset( $args['profile'] );
+		}
+
 		if ( ! isset( $this->clients[ $client_key ] ) ) {
-			$this->clients[ $client_key ] = new DynamoDbClient(
-				[
-					'region'  => $region,
-					'profile' => $profile,
-					'version' => '2012-08-10',
-					'csm'     => false,
-				]
-			);
+			$this->clients[ $client_key ] = new DynamoDbClient( $args );
 		}
 
 		return $this->clients[ $client_key ];

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -233,16 +233,22 @@ class S3StorageConnector implements StorageConnectorInterface {
 	private function get_client( string $profile, string $region ) : S3Client {
 		$client_key = $profile . '_' . $region;
 
+		$args = [
+			'region'    => $region,
+			'profile'   => $profile,
+			'signature' => 'v4',
+			'version'   => '2006-03-01',
+			'csm'       => false,
+		];
+
+		// Check if the necessary AWS env vars are set; if so, the profile arg is not needed.
+		// These are the same env vars the SDK checks for in CredentialProvider.php.
+		if ( getenv( 'AWS_ACCESS_KEY_ID' ) && getenv( 'AWS_SECRET_ACCESS_KEY' ) ) {
+			unset( $args['profile'] );
+		}
+
 		if ( ! isset( $this->clients[ $client_key ] ) ) {
-			$this->clients[ $client_key ] = new S3Client(
-				[
-					'region'    => $region,
-					'profile'   => $profile,
-					'signature' => 'v4',
-					'version'   => '2006-03-01',
-					'csm'       => false,
-				]
-			);
+			$this->clients[ $client_key ] = new S3Client( $args );
 		}
 
 		return $this->clients[ $client_key ];


### PR DESCRIPTION
If the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set as env vars, authentication by env var will be prioritized over .aws/credentials. .aws/credentials is ignored in this scenario so doesn't need to be moved or deleted if it exists.