### PR TITLE
Support pushing existing snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,16 @@ Pushing a snapshot will not replace older snapshots with the same name. Each tim
 
 #### Command
 
-__wp snapshots push [--repository=\<repository\>] [--exclude=\<exclude\>] [--slug=\<slug\>] [--description=\<description\>] [--wp_version=\<wp_version\>] [--author_name=\<author_name\>]
+__wp snapshots push [<snapshot_id>] [--repository=\<repository\>] [--exclude=\<exclude\>] [--slug=\<slug\>] [--description=\<description\>] [--wp_version=\<wp_version\>] [--author_name=\<author_name\>]
   [--author_email=\<author_email\>] [--exclude_uploads] [--small] [--include_files] [--include_db]__
 
 <details>
 <summary>Show Arguments</summary>
 
 ```
+  <snapshot_id>
+    ID of local snapshot to push.
+
   [--repository=<repository>]
     Repository to use.
     ---

--- a/includes/classes/Snapshots/FileZipper.php
+++ b/includes/classes/Snapshots/FileZipper.php
@@ -49,7 +49,7 @@ class FileZipper implements SharedService {
 	public function zip_files( string $id, array $args ) : int {
 		$this->snapshot_files->create_directory( $id );
 
-		$excludes = [];
+		$excludes = [ './plugins/snapshots' ];
 
 		$command = 'cd ' . escapeshellarg( snapshots_wp_content_dir() ) . '/ && tar ';
 
@@ -79,10 +79,7 @@ class FileZipper implements SharedService {
 			$excludes[] = './**/vendor';
 		}
 
-		if ( ! empty( $excludes ) ) {
-			$command .= '--exclude=' . implode( ' --exclude=', array_map( 'escapeshellarg', $excludes ) ) . ' ';
-		}
-
+		$command .= '--exclude=' . implode( ' --exclude=', array_map( 'escapeshellarg', $excludes ) ) . ' ';
 		$command .= '-czf ' . escapeshellarg( $this->snapshot_files->get_file_path( 'files.tar.gz', $id ) ) . ' .';
 
 		$exit_code = 0;

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -132,7 +132,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 		$meta   = $this->snapshot_meta->get_local( $id, $repository );
 		$client = $this->get_client( $profile, $region );
 
-		if ( $meta['contains_db'] ) {
+		if ( $meta['contains_db'] && file_exists( $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ) ) ) {
 			$client->putObject(
 				[
 					'Bucket'     => $this->get_bucket_name( $repository ),
@@ -143,7 +143,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 			);
 		}
 
-		if ( $meta['contains_files'] ) {
+		if ( $meta['contains_files'] && file_exists( $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ) ) ) {
 			$client->putObject(
 				[
 					'Bucket'     => $this->get_bucket_name( $repository ),

--- a/includes/classes/WPCLICommands/Create.php
+++ b/includes/classes/WPCLICommands/Create.php
@@ -65,14 +65,7 @@ class Create extends WPCLICommand {
 			$this->set_args( $args );
 			$this->set_assoc_args( $assoc_args );
 
-			$contains_db    = $this->prompt->get_flag_or_prompt( $this->get_assoc_args(), 'include_db', 'Include database in snapshot?', true );
-			$contains_files = $this->prompt->get_flag_or_prompt( $this->get_assoc_args(), 'include_files', 'Include files in snapshot?', true );
-
-			if ( ! $contains_db && ! $contains_files ) {
-				throw new SnapshotsException( 'You must include either the database or files in the snapshot.' );
-			}
-
-			$id = $this->run( $contains_db, $contains_files );
+			$id = $this->run();
 
 			wp_cli()::success( $this->get_success_message( $id ) );
 		} catch ( Exception $e ) {
@@ -197,14 +190,18 @@ class Create extends WPCLICommand {
 	/**
 	 * Runs the command.
 	 *
-	 * @param bool $contains_db Whether the snapshot contains a database.
-	 * @param bool $contains_files Whether the snapshot contains files.
-	 *
 	 * @return string
 	 *
 	 * @throws SnapshotsException If the snapshot cannot be created.
 	 */
-	public function run( bool $contains_db, bool $contains_files ) : string {
+	public function run() : string {
+		$contains_db    = $this->prompt->get_flag_or_prompt( $this->get_assoc_args(), 'include_db', 'Include database in snapshot?', true );
+		$contains_files = $this->prompt->get_flag_or_prompt( $this->get_assoc_args(), 'include_files', 'Include files in snapshot?', true );
+
+		if ( ! $contains_db && ! $contains_files ) {
+			throw new SnapshotsException( 'You must include either the database or files in the snapshot.' );
+		}
+
 		$id = md5( time() . wp_rand() );
 		$this->snapshots_filesystem->create_directory( $id );
 		return $this->create( $this->get_create_args( $contains_db, $contains_files ), $id );

--- a/includes/classes/WPCLICommands/Push.php
+++ b/includes/classes/WPCLICommands/Push.php
@@ -26,14 +26,15 @@ final class Push extends Create {
 	/**
 	 * Runs the command.
 	 *
-	 * @param bool $contains_db Whether the snapshot contains a database.
-	 * @param bool $contains_files Whether the snapshot contains files.
-	 *
 	 * @return string
 	 */
-	public function run( bool $contains_db, bool $contains_files ) : string {
-		// Run the parent run method.
-		$id = parent::run( $contains_db, $contains_files );
+	public function run() : string {
+		$id = $this->get_args()[0] ?? null;
+
+		if ( ! $id ) {
+			// Run the parent run method.
+			$id = parent::run();
+		}
 
 		$this->log( 'Pushing snapshot to remote repository...' );
 
@@ -45,6 +46,25 @@ final class Push extends Create {
 		$this->db_connector->insert_snapshot( $id, $profile, $repository_name, $region, $this->snapshot_meta->get_local( $id, $repository_name ) );
 
 		return $id;
+	}
+
+	/**
+	 * Provides command parameters.
+	 *
+	 * @inheritDoc
+	 */
+	protected function get_command_parameters() : array {
+		$parameters = parent::get_command_parameters();
+
+		// Add anid parameter to push a snapshot that already exists locally.
+		$parameters['synopsis'][] = [
+			'type'        => 'positional',
+			'name'        => 'snapshot_id',
+			'description' => 'ID of local snapshot to push',
+			'optional'    => true,
+		];
+
+		return $parameters;
 	}
 
 	/**


### PR DESCRIPTION
Closes #42 

If a snapshot was created but not pushed (i.e., with the `create` command), this PR adds support for pushing that existing snapshot. Previously the `push` command could only push newly created snapshots. 