### PR TITLE
demo role_arn fixes

### DIFF
--- a/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
+++ b/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
@@ -137,6 +137,18 @@ class SnapshotsConfigFromFileSystem implements SnapshotsConfigInterface {
 	}
 
 	/**
+	 * Gets the roleArn property from a repository. Defaults to ''.
+	 *
+	 * @param string $repository Repository name.
+	 * @return string $profile Profile name.
+	 */
+	public function get_repository_role_arn( string $repository = '' ) : string {
+		$settings = $this->get_repository_settings( $repository );
+
+		return $settings['roleArn'] ?? '';
+	}
+
+	/**
 	 * Gets the default repository name.
 	 *
 	 * @return ?string $repository Default repository name.

--- a/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
+++ b/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
@@ -130,10 +130,10 @@ class SnapshotsConfigFromFileSystem implements SnapshotsConfigInterface {
 		$settings = $this->get_repository_settings( $repository );
 
 		if ( is_array( $settings ) ) {
-			return $settings['profile'] ?? 'default';
+			return $settings['profile'] ?? '';
 		}
 
-		return 'default';
+		return '';
 	}
 
 	/**
@@ -145,7 +145,11 @@ class SnapshotsConfigFromFileSystem implements SnapshotsConfigInterface {
 	public function get_repository_role_arn( string $repository = '' ) : string {
 		$settings = $this->get_repository_settings( $repository );
 
-		return $settings['roleArn'] ?? '';
+		if ( is_array( $settings ) ) {
+			return $settings['roleArn'] ?? '';
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/classes/SnapshotsConfig/SnapshotsConfigInterface.php
+++ b/includes/classes/SnapshotsConfig/SnapshotsConfigInterface.php
@@ -57,6 +57,14 @@ interface SnapshotsConfigInterface extends SharedService {
 	public function get_repository_profile( string $repository = '' ) : ?string;
 
 	/**
+	 * Gets the roleArn property from a repository.
+	 *
+	 * @param string $repository Repository name.
+	 * @return ?string $roleArn Role ARN string.
+	 */
+	public function get_repository_role_arn( string $repository = '' ) : ?string;
+
+	/**
 	 * Gets repositories.
 	 *
 	 * @return array

--- a/includes/classes/WPCLI/WPCLICommand.php
+++ b/includes/classes/WPCLI/WPCLICommand.php
@@ -283,6 +283,9 @@ abstract class WPCLICommand implements Conditional, Module {
 
 		$profile = $this->config->get_repository_profile( $repository_name );
 
+		// FIXME: hack to get the role_arn available later for demo purposes
+		$_ENV['role_arn'] = $this->config->get_repository_role_arn( $repository_name );
+
 		return $profile;
 	}
 


### PR DESCRIPTION
I'm not familiar enough with the design pattern used here to properly modify the code, so for demo purposes and testing I have created this PR for #47 which contains a hack to get the role_arn value from the wpsnaphots config file to where it needs to be to assume roles.

These changes, in my testing, allow for the original design to work using profiles while also supporting ENV vars and role_arns when present in the config file. What does _not_ work is having credentials hardcoded in the wpsnapshots config file. Adding the ability to load this information from wpsnapshots config would provide backwards compatibility, however.

I tested the following scenarios:

* wpsnapshots configuration contains a valid "roleArn" value and no profile value
* wpsnapshots configuration contains valid "profile" value with hard coded AWS credentials in ~/.aws/credentials
* wpsnapshots configuration with no roleArn or profile and will use the default AWS profile if configured in ~/.aws
* wpsnapshots configuration with no roleArn or profile but with AWS environment variables set
* wpsnapshots has invalid roleArn configured
* also tested against an AWS account with MFA enabled

I did not test this on an ec2 instance with an IAM role assigned but presumably it would work.