### PR TITLE
Feature/role arn

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [ "trunk", "develop" ]
   pull_request:
-    branches: [ "trunk", "develop", "feature/*" ]
+    branches: [ "*" ]
 
 jobs:
   phpcs:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Snapshots relies on AWS to store files and data. As such, you need to connect to
 
 #### Command
 
-__wp snapshots configure <repository> [--region=\<region\>] [--user_name=\<user_name\>] [--user_email=\<user_email\>]__
+__wp snapshots configure <repository> [--region=\<region\>] [--profile=\<profile\>] [--user_name=\<user_name\>] [--user_email=\<user_email\>] [--role_arn=\<role_arn\>]__
 
 <details>
 <summary>Show Arguments</summary>
@@ -106,8 +106,14 @@ __wp snapshots configure <repository> [--region=\<region\>] [--user_name=\<user_
   [--user_name=<user_name>]
     The username to use. If it's not provided, user will be prompted for it.
 
+  [--profile=<profile>]
+    AWS profile.
+
   [--user_email=<user_email>]
     The user email to use. If it's not provided, user will be prompted for it.
+
+  [--role_arn=<role_arn>]
+    Role ARN for AWS. Probably don't need this.
 ```
 </details>
 

--- a/includes/classes/Snapshots/DBConnectorInterface.php
+++ b/includes/classes/Snapshots/DBConnectorInterface.php
@@ -20,51 +20,41 @@ interface DBConnectorInterface extends SharedService {
 	 * Searches the database.
 	 *
 	 * @param  string|array $query Search query string
-	 * @param string       $profile AWS profile.
-	 * @param  string       $repository Repository name
-	 * @param string       $region AWS region
+	 * @param array        $config AWS config
 	 * @return array
 	 */
-	public function search( $query, string $profile, string $repository, string $region ) : array;
+	public function search( $query, array $config ) : array;
 
 	/**
 	 * Get a snapshot given an id
 	 *
 	 * @param  string $id Snapshot ID
-	 * @param string $profile AWS profile.
-	 * @param  string $repository Repository name
-	 * @param string $region AWS region
+	 * @param array  $config AWS config
 	 * @return mixed
 	 */
-	public function get_snapshot( string $id, string $profile, string $repository, string $region );
+	public function get_snapshot( string $id, array $config );
 
 	/**
 	 * Create default DB tables. Only need to do this once ever for repo setup.
 	 *
-	 * @param string $profile AWS profile.
-	 * @param string $repository Repository name
-	 * @param string $region AWS region
+	 * @param array $config AWS config
 	 */
-	public function create_tables( string $profile, string $repository, string $region );
+	public function create_tables( array $config );
 
 	/**
 	 * Insert a snapshot into the DB
 	 *
 	 * @param  string $id Snapshot ID
-	 * @param string $profile AWS profile.
-	 * @param  string $repository Repository name.
-	 * @param string $region AWS region.
+	 * @param array  $config AWS config
 	 * @param array  $meta Snapshot meta.
 	 */
-	public function insert_snapshot( string $id, string $profile, string $repository, string $region, array $meta ) : void;
+	public function insert_snapshot( string $id, array $config, array $meta ) : void;
 
 	/**
 	 * Delete a snapshot given an id
 	 *
 	 * @param  string $id Snapshot ID
-	 * @param string $profile AWS profile.
-	 * @param string $repository Repository name.
-	 * @param string $region AWS region.
+	 * @param array  $config AWS config
 	 */
-	public function delete_snapshot( string $id, string $profile, string $repository, string $region ) : void;
+	public function delete_snapshot( string $id, array $config ) : void;
 }

--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -18,11 +18,11 @@ use TenUp\Snapshots\Exceptions\SnapshotsException;
 class DynamoDBConnector implements DBConnectorInterface {
 
 	/**
-	 * Clients keyed by region.
+	 * Client
 	 *
-	 * @var DynamoDbClient[]
+	 * @var ?DynamoDbClient
 	 */
-	private $clients = [];
+	private $client = null;
 
 	/**
 	 * Searches the database.
@@ -203,7 +203,9 @@ class DynamoDBConnector implements DBConnectorInterface {
 	 * @throws SnapshotsException Failed to assume ARN role
 	 */
 	private function get_client( array $config ) : DynamoDbClient {
-		$client_key = $config['profile'] . '_' . $config['region'];
+		if ( ! is_null( $this->client ) ) {
+			return $this->client;
+		}
 
 		$args = [
 			'region'  => $config['region'],
@@ -231,11 +233,9 @@ class DynamoDBConnector implements DBConnectorInterface {
 			$args['profile'] = $config['profile'];
 		}
 
-		if ( ! isset( $this->clients[ $client_key ] ) ) {
-			$this->clients[ $client_key ] = new DynamoDbClient( $args );
-		}
+		$this->client = new DynamoDbClient( $args );
 
-		return $this->clients[ $client_key ];
+		return $this->client;
 	}
 
 	/**

--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -244,7 +244,7 @@ class DynamoDBConnector implements DBConnectorInterface {
 	 * @param array $connection_parameters Parameters for connection
 	 * @return array
 	 */
-	private function assume_role( $connection_parameters ) : array {
+	private function assume_role( $connection_parameters ) {
 		$sts_client = new Aws\Sts\StsClient(
 			[
 				'region'  => 'us-east-1',

--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -242,7 +242,7 @@ class DynamoDBConnector implements DBConnectorInterface {
 	 * Performs STS
 	 *
 	 * @param array $connection_parameters Parameters for connection
-	 * @return array
+	 * @return mixed
 	 */
 	private function assume_role( $connection_parameters ) {
 		$sts_client = new Aws\Sts\StsClient(

--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -200,6 +200,7 @@ class DynamoDBConnector implements DBConnectorInterface {
 	 * @param array $config AWS config
 	 *
 	 * @return DynamoDbClient
+	 * @throws SnapshotsException Failed to assume ARN role
 	 */
 	private function get_client( array $config ) : DynamoDbClient {
 		$client_key = $config['profile'] . '_' . $config['region'];

--- a/includes/classes/Snapshots/DynamoDBConnector.php
+++ b/includes/classes/Snapshots/DynamoDBConnector.php
@@ -252,7 +252,7 @@ class DynamoDBConnector implements DBConnectorInterface {
 			]
 		);
 
-		$result = $sts_client->AssumeRole(
+		$result = $sts_client->assumeRole(
 			[
 				'RoleArn'         => $connection_parameters['roleArn'],
 				'RoleSessionName' => 'wpsnapshots',

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -262,7 +262,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 	 * Performs STS
 	 *
 	 * @param array $connection_parameters Parameters for connection
-	 * @return array
+	 * @return mixed
 	 */
 	private function assume_role( $connection_parameters ) {
 		$sts_client = new Aws\Sts\StsClient(

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -219,6 +219,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 	 *
 	 * @param array $config AWS config
 	 * @return S3Client
+	 * @throws SnapshotsException Failed to assume ARN role
 	 */
 	private function get_client( array $config ) : S3Client {
 		$client_key = $config['profile'] . '_' . $config['region'];

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -264,7 +264,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 	 * @param array $connection_parameters Parameters for connection
 	 * @return array
 	 */
-	private function assume_role( $connection_parameters ) : array {
+	private function assume_role( $connection_parameters ) {
 		$sts_client = new Aws\Sts\StsClient(
 			[
 				'region'  => 'us-east-1',

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -272,7 +272,7 @@ class S3StorageConnector implements StorageConnectorInterface {
 			]
 		);
 
-		$result = $sts_client->AssumeRole(
+		$result = $sts_client->assumeRole(
 			[
 				'RoleArn'         => $connection_parameters['roleArn'],
 				'RoleSessionName' => 'wpsnapshots',

--- a/includes/classes/Snapshots/SnapshotMeta.php
+++ b/includes/classes/Snapshots/SnapshotMeta.php
@@ -57,13 +57,11 @@ abstract class SnapshotMeta implements SnapshotMetaInterface {
 	 * Download meta from remote DB
 	 *
 	 * @param string $id Snapshot ID
-	 * @param string $profile AWS profile
-	 * @param string $repository Repository name
-	 * @param string $region AWS region
+	 * @param array  $config AWS config
 	 * @return array
 	 */
-	public function get_remote( string $id, string $profile, string $repository, string $region ) : array {
-		$snapshot_meta = $this->db->get_snapshot( $id, $profile, $repository, $region );
+	public function get_remote( string $id, array $config ) : array {
+		$snapshot_meta = $this->db->get_snapshot( $id, $config );
 
 		if ( empty( $snapshot_meta ) ) {
 			return [];
@@ -78,7 +76,7 @@ abstract class SnapshotMeta implements SnapshotMetaInterface {
 			$snapshot_meta['contains_db'] = true;
 		}
 
-		$snapshot_meta['repository'] = $repository;
+		$snapshot_meta['repository'] = $config['repository'];
 
 		return $snapshot_meta;
 	}

--- a/includes/classes/Snapshots/SnapshotMetaInterface.php
+++ b/includes/classes/Snapshots/SnapshotMetaInterface.php
@@ -30,12 +30,10 @@ interface SnapshotMetaInterface extends SharedService {
 	 * Download meta from remote DB
 	 *
 	 * @param string $id Snapshot ID
-	 * @param string $profile AWS profile
-	 * @param string $repository Repository name
-	 * @param string $region AWS region
+	 * @param array  $config AWS config
 	 * @return array
 	 */
-	public function get_remote( string $id, string $profile, string $repository, string $region ) : array;
+	public function get_remote( string $id, array $config ) : array;
 
 	/**
 	 * Get local snapshot meta

--- a/includes/classes/Snapshots/StorageConnectorInterface.php
+++ b/includes/classes/Snapshots/StorageConnectorInterface.php
@@ -20,24 +20,20 @@ interface StorageConnectorInterface extends SharedService {
 	/**
 	 * Download a snapshot given an id. Must specify where to download files/data
 	 *
-	 * @param  string $id Snapshot ID
+	 * @param string $id Snapshot ID
+	 * @param array  $config AWS config array
 	 * @param array  $snapshot_meta Snapshot meta.
-	 * @param string $profile AWS profile.
-	 * @param string $repository Repository name
-	 * @param string $region AWS region
 	 */
-	public function download_snapshot( string $id, array $snapshot_meta, string $profile, string $repository, string $region );
+	public function download_snapshot( string $id, array $config, array $snapshot_meta );
 
 	/**
 	 * Create Snapshots S3 bucket
 	 *
-	 * @param string $profile AWS profile.
-	 * @param string $repository Repository name.
-	 * @param string $region AWS region.
+	 * @param array $config AWS config
 	 *
 	 * @throws SnapshotsException If bucket already exists.
 	 */
-	public function create_bucket( string $profile, string $repository, string $region );
+	public function create_bucket( array $config );
 
 	/**
 	 * Gets the bucket already exists error message.
@@ -50,29 +46,23 @@ interface StorageConnectorInterface extends SharedService {
 	 * Upload a snapshot to S3
 	 *
 	 * @param  string $id Snapshot ID
-	 * @param string $profile AWS profile.
-	 * @param string $repository Repository name.
-	 * @param string $region AWS region.
+	 * @param array  $config AWS config
 	 */
-	public function put_snapshot( string $id, string $profile, string $repository, string $region ) : void;
+	public function put_snapshot( string $id, array $config ) : void;
 
 	/**
 	 * Delete a snapshot given an id
 	 *
 	 * @param  string $id Snapshot id
 	 * @param  string $project Project name
-	 * @param string $profile AWS profile.
-	 * @param  string $repository Repository name
-	 * @param  string $region AWS region
+	 * @param array  $config AWS config
 	 */
-	public function delete_snapshot( string $id, string $project, string $profile, string $repository, string $region ) : void;
+	public function delete_snapshot( string $id, string $project, array $config ) : void;
 
 	/**
 	 * Tests the user's AWS credentials.
 	 *
-	 * @param string $profile AWS profile.
-	 * @param string $repository Repository name.
-	 * @param string $region AWS region.
+	 * @param array $config AWS config
 	 */
-	public function test( string $profile, string $repository, string $region );
+	public function test( array $config );
 }

--- a/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
+++ b/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
@@ -137,6 +137,18 @@ class SnapshotsConfigFromFileSystem implements SnapshotsConfigInterface {
 	}
 
 	/**
+	 * Gets the roleArn property from a repository. Defaults to ''.
+	 *
+	 * @param string $repository Repository name.
+	 * @return string $profile Profile name.
+	 */
+	public function get_repository_role_arn( string $repository = '' ) : string {
+		$settings = $this->get_repository_settings( $repository );
+
+		return $settings['roleArn'] ?? '';
+	}
+
+	/**
 	 * Gets the default repository name.
 	 *
 	 * @return ?string $repository Default repository name.

--- a/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
+++ b/includes/classes/SnapshotsConfig/SnapshotsConfigFromFileSystem.php
@@ -130,10 +130,10 @@ class SnapshotsConfigFromFileSystem implements SnapshotsConfigInterface {
 		$settings = $this->get_repository_settings( $repository );
 
 		if ( is_array( $settings ) ) {
-			return $settings['profile'] ?? 'default';
+			return $settings['profile'] ?? '';
 		}
 
-		return 'default';
+		return '';
 	}
 
 	/**
@@ -145,7 +145,11 @@ class SnapshotsConfigFromFileSystem implements SnapshotsConfigInterface {
 	public function get_repository_role_arn( string $repository = '' ) : string {
 		$settings = $this->get_repository_settings( $repository );
 
-		return $settings['roleArn'] ?? '';
+		if ( is_array( $settings ) ) {
+			return $settings['roleArn'] ?? '';
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/classes/SnapshotsConfig/SnapshotsConfigInterface.php
+++ b/includes/classes/SnapshotsConfig/SnapshotsConfigInterface.php
@@ -57,6 +57,14 @@ interface SnapshotsConfigInterface extends SharedService {
 	public function get_repository_profile( string $repository = '' ) : ?string;
 
 	/**
+	 * Gets the roleArn property from a repository.
+	 *
+	 * @param string $repository Repository name.
+	 * @return ?string $roleArn Role ARN string.
+	 */
+	public function get_repository_role_arn( string $repository = '' ) : ?string;
+
+	/**
 	 * Gets repositories.
 	 *
 	 * @return array

--- a/includes/classes/WPCLI/WPCLICommand.php
+++ b/includes/classes/WPCLI/WPCLICommand.php
@@ -283,6 +283,9 @@ abstract class WPCLICommand implements Conditional, Module {
 
 		$profile = $this->config->get_repository_profile( $repository_name );
 
+		// FIXME: hack to get the role_arn available later for demo purposes
+		$_ENV['role_arn'] = $this->config->get_repository_role_arn( $repository_name );
+
 		return $profile;
 	}
 

--- a/includes/classes/WPCLI/WPCLICommand.php
+++ b/includes/classes/WPCLI/WPCLICommand.php
@@ -272,6 +272,43 @@ abstract class WPCLICommand implements Conditional, Module {
 	}
 
 	/**
+	 * Gets the role arn from the repository.
+	 *
+	 * @param ?string $repository_name Repository name.
+	 *
+	 * @return string
+	 */
+	protected function get_role_arn( ?string $repository_name = null ) : string {
+		if ( ! $repository_name ) {
+			$repository_name = $this->get_repository_name();
+		}
+
+		$role_arn = $this->config->get_repository_role_arn( $repository_name );
+
+		return $role_arn;
+	}
+
+	/**
+	 * Get prepared AWS config
+	 *
+	 * @param ?string $repository_name Repository name.
+	 *
+	 * @return array
+	 */
+	protected function get_aws_config( ?string $repository_name = null ) : array {
+		if ( ! $repository_name ) {
+			$repository_name = $this->get_repository_name();
+		}
+
+		return [
+			'profile'    => $this->get_profile_for_repository(),
+			'repository' => $this->get_repository_name(),
+			'region'     => $this->get_region(),
+			'role_arn'   => $this->get_role_arn(),
+		];
+	}
+
+	/**
 	 * Gets the profile property from the repository.
 	 *
 	 * @return string
@@ -282,9 +319,6 @@ abstract class WPCLICommand implements Conditional, Module {
 		$repository_name = $this->get_repository_name();
 
 		$profile = $this->config->get_repository_profile( $repository_name );
-
-		// FIXME: hack to get the role_arn available later for demo purposes
-		$_ENV['role_arn'] = $this->config->get_repository_role_arn( $repository_name );
 
 		return $profile;
 	}

--- a/includes/classes/WPCLICommands/Configure.php
+++ b/includes/classes/WPCLICommands/Configure.php
@@ -35,9 +35,16 @@ final class Configure extends WPCLICommand {
 
 			$this->config->save();
 
+			$config = [
+				'profile'    => $this->get_profile(),
+				'repository' => $this->get_repository_name( true, 0 ),
+				'region'     => $this->get_region_arg(),
+				'role_arn'   => $this->get_assoc_arg( 'role_arn' ),
+			];
+
 			try {
 				$this->log( 'Testing repository connection...' );
-				$this->storage_connector->test( $this->get_profile(), $this->get_repository_name( true, 0 ), $this->get_region_arg() );
+				$this->storage_connector->test( $config );
 			} catch ( Exception $e ) {
 				wp_cli()::error( 'Your Snapshots configuration is saved, but we were unable to connect to the repository. Please check your AWS credentials.' );
 			}
@@ -86,6 +93,12 @@ final class Configure extends WPCLICommand {
 					'type'        => 'assoc',
 					'name'        => 'profile',
 					'description' => 'The AWS profile to use. Defaults to \'default\'.',
+					'optional'    => true,
+				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'role_arn',
+					'description' => 'AWS role ARN. Defaults to none',
 					'optional'    => true,
 				],
 			],
@@ -170,7 +183,7 @@ final class Configure extends WPCLICommand {
 			'profile',
 			[
 
-				'prompt'  => 'Which AWS authentication profile should be used for this profile? If you are unsure, leave this blank to use the default.',
+				'prompt'  => 'Which AWS authentication profile should be used for this profile? If you are unsure, use `default`',
 				'default' => 'default',
 			]
 		);

--- a/includes/classes/WPCLICommands/Configure.php
+++ b/includes/classes/WPCLICommands/Configure.php
@@ -140,7 +140,7 @@ final class Configure extends WPCLICommand {
 			$role_arn = '';
 		}
 
-		$region   = $this->get_region_arg();
+		$region = $this->get_region_arg();
 
 		$repositories[ $repository_name ] = [
 			'region'     => $region,

--- a/includes/classes/WPCLICommands/CreateRepository.php
+++ b/includes/classes/WPCLICommands/CreateRepository.php
@@ -30,12 +30,15 @@ final class CreateRepository extends WPCLICommand {
 			$this->set_args( $args );
 			$this->set_assoc_args( $assoc_args );
 
-			$repository_name = $this->get_repository_name( true, 0 );
-			$region          = $this->get_assoc_arg( 'region' );
-			$profile         = $this->get_assoc_arg( 'profile' );
+			$config = [
+				'repository' => $this->get_repository_name( true, 0 ),
+				'region'     => $this->get_assoc_arg( 'region' ),
+				'profile'    => $this->get_assoc_arg( 'profile' ),
+				'role_arn'   => $this->get_assoc_arg( 'role_arn' ),
+			];
 
-			$this->storage_connector->create_bucket( $profile, $repository_name, $region );
-			$this->db_connector->create_tables( $profile, $repository_name, $region );
+			$this->storage_connector->create_bucket( $config );
+			$this->db_connector->create_tables( $config );
 		} catch ( Exception $e ) {
 			wp_cli()::error( $e->getMessage() );
 		}
@@ -80,6 +83,12 @@ final class CreateRepository extends WPCLICommand {
 					'description' => 'The AWS profile to use',
 					'optional'    => true,
 					'default'     => 'default',
+				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'role_arn',
+					'description' => 'The AWS role ARN to use',
+					'optional'    => true,
 				],
 			],
 			'when'      => 'before_wp_load',

--- a/includes/classes/WPCLICommands/Delete.php
+++ b/includes/classes/WPCLICommands/Delete.php
@@ -38,14 +38,14 @@ class Delete extends WPCLICommand {
 			$region          = $this->get_region();
 			$profile         = $this->get_profile_for_repository();
 
-			$snapshot = $this->db_connector->get_snapshot( $id, $profile, $repository_name, $region );
+			$snapshot = $this->db_connector->get_snapshot( $id, $this->get_aws_config() );
 
 			if ( ! $snapshot ) {
 				throw new SnapshotsException( sprintf( 'Snapshot %s not found in repository %s.', $id, $repository_name ) );
 			}
 
-			$this->storage_connector->delete_snapshot( $id, $snapshot['project'], $profile, $repository_name, $region );
-			$this->db_connector->delete_snapshot( $id, $profile, $repository_name, $region );
+			$this->storage_connector->delete_snapshot( $id, $snapshot['project'], $this->get_aws_config() );
+			$this->db_connector->delete_snapshot( $id, $this->get_aws_config() );
 
 			wp_cli()::success( sprintf( 'Snapshot %s deleted.', $id ) );
 		} catch ( Exception $e ) {

--- a/includes/classes/WPCLICommands/Download.php
+++ b/includes/classes/WPCLICommands/Download.php
@@ -35,7 +35,7 @@ final class Download extends WPCLICommand {
 
 			$this->log( 'Downloading snapshot (' . $this->get_formatted_size( $meta ) . ')...' );
 
-			$this->storage_connector->download_snapshot( $this->get_id(), $meta, $this->get_profile_for_repository(), $this->get_repository_name(), $this->get_region() );
+			$this->storage_connector->download_snapshot( $this->get_id(), $this->get_aws_config(), $meta );
 			$this->snapshot_meta->save_local( $this->get_id(), $meta );
 
 			wp_cli()::success( 'Snapshot downloaded.' );
@@ -112,7 +112,7 @@ final class Download extends WPCLICommand {
 	private function get_meta() : array {
 		$id = $this->get_id();
 
-		$meta = $this->snapshot_meta->get_remote( $id, $this->get_profile_for_repository(), $this->get_repository_name(), $this->get_region() );
+		$meta = $this->snapshot_meta->get_remote( $id, $this->get_aws_config() );
 
 		if ( empty( $meta ) ) {
 			throw new SnapshotsException( 'Snapshot does not exist.' );

--- a/includes/classes/WPCLICommands/Pull.php
+++ b/includes/classes/WPCLICommands/Pull.php
@@ -265,7 +265,7 @@ final class Pull extends WPCLICommand {
 		$id              = $this->get_id();
 		$repository_name = $this->get_repository_name();
 
-		$remote_meta = $this->snapshot_meta->get_remote( $id, $this->get_profile_for_repository(), $repository_name, $this->get_region() );
+		$remote_meta = $this->snapshot_meta->get_remote( $id, $this->get_aws_config() );
 		$local_meta  = $this->snapshot_meta->get_local( $id, $repository_name );
 
 		switch ( true ) {

--- a/includes/classes/WPCLICommands/Push.php
+++ b/includes/classes/WPCLICommands/Push.php
@@ -42,8 +42,8 @@ final class Push extends Create {
 		$region          = $this->get_region();
 		$profile         = $this->get_profile_for_repository();
 
-		$this->storage_connector->put_snapshot( $id, $profile, $repository_name, $region );
-		$this->db_connector->insert_snapshot( $id, $profile, $repository_name, $region, $this->snapshot_meta->get_local( $id, $repository_name ) );
+		$this->storage_connector->put_snapshot( $id, $this->get_aws_config() );
+		$this->db_connector->insert_snapshot( $id, $this->get_aws_config(), $this->snapshot_meta->get_local( $id, $repository_name ) );
 
 		return $id;
 	}

--- a/includes/classes/WPCLICommands/Search.php
+++ b/includes/classes/WPCLICommands/Search.php
@@ -101,7 +101,7 @@ final class Search extends WPCLICommand {
 	 * @return array
 	 */
 	private function search() {
-		return $this->db_connector->search( $this->get_search_string(), $this->get_profile_for_repository(), $this->get_repository_name(), $this->get_region() );
+		return $this->db_connector->search( $this->get_search_string(), $this->get_aws_config() );
 	}
 
 	/**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,6 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- %currentWorkingDirectory%/includes/
-		- %currentWorkingDirectory%/tests/php/
 	bootstrapFiles:
 		- %currentWorkingDirectory%/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 		- %currentWorkingDirectory%/snapshots.php

--- a/tests/php/includes/Snapshots/TestDBConnector.php
+++ b/tests/php/includes/Snapshots/TestDBConnector.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tests for the DynamoDBConnector class.
- * 
+ *
  * @package TenUp\Snapshots
  */
 
@@ -17,7 +17,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * Class TestDBConnector
  *
  * @package TenUp\Snapshots\Tests\Snapshots
- * 
+ *
  * @coversDefaultClass \TenUp\Snapshots\Snapshots\DynamoDBConnector
  */
 class TestDBConnector extends TestCase {
@@ -26,7 +26,7 @@ class TestDBConnector extends TestCase {
 
 	/**
 	 * DynamoDBConnector instance.
-	 * 
+	 *
 	 * @var DynamoDBConnector
 	 */
 	private $connector;
@@ -55,7 +55,7 @@ class TestDBConnector extends TestCase {
 
 	/** @covers ::get_client */
 	public function test_get_client() {
-		$client = $this->call_private_method( $this->connector, 'get_client', [ 'default', 'test-repo' ] );
+		$client = $this->call_private_method( $this->connector, 'get_client', [ [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1' ] ] );
 
 		$this->assertInstanceOf( DynamoDbClient::class, $client );
 	}
@@ -64,7 +64,7 @@ class TestDBConnector extends TestCase {
 	public function test_search_client_is_called_with_expected_args() {
 		/**
 		 * DynamoDBClient mock.
-		 * 
+		 *
 		 * @var MockObject $client
 		 */
 		$client = $this->createMock( DynamoDbClient::class );
@@ -93,14 +93,14 @@ class TestDBConnector extends TestCase {
 		);
 
 		// Call search method.
-		$this->connector->search( 'search term', 'default', 'test-repo', 'test-region' );
+		$this->connector->search( 'search term', [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1' ] );
 	}
 
 	/** @covers ::get_snapshot */
 	public function test_get_snapshot_client_is_called_with_expected_args() {
 		/**
 		 * DynamoDBClient mock.
-		 * 
+		 *
 		 * @var MockObject $client
 		 */
 		$client = $this->getMockBuilder( DynamoDbClient::class )
@@ -124,14 +124,14 @@ class TestDBConnector extends TestCase {
 		);
 
 		// Call get_snapshot method.
-		$this->connector->get_snapshot( 'snapshot-id', 'default', 'test-repo', 'test-region' );
+		$this->connector->get_snapshot( 'snapshot-id', [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1' ] );
 	}
 
 	/** @covers ::create_tables */
 	public function test_create_tables_client_is_called_with_expected_args() {
 		/**
 		 * DynamoDBClient mock.
-		 * 
+		 *
 		 * @var MockObject $client
 		 */
 		$client = $this->getMockBuilder( DynamoDbClient::class )
@@ -176,6 +176,6 @@ class TestDBConnector extends TestCase {
 		);
 
 		// Call create_tables method.
-		$this->connector->create_tables( 'default', 'test-repo', 'test-region' );
+		$this->connector->create_tables( [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ] );
 	}
 }

--- a/tests/php/includes/Snapshots/TestDBConnector.php
+++ b/tests/php/includes/Snapshots/TestDBConnector.php
@@ -71,7 +71,7 @@ class TestDBConnector extends TestCase {
 		$client->method( 'getIterator' )->willReturn( [] );
 
 		// Set client as private property.
-		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'client', $client );
 
 		// Assert that client's getIterator method was called with expected args.
 		$client->expects( $this->once() )->method( 'getIterator' )->with(
@@ -110,7 +110,7 @@ class TestDBConnector extends TestCase {
 		$client->method( 'getItem' )->willReturn( [] );
 
 		// Set client as private property.
-		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'client', $client );
 
 		// Assert that client's getItem method was called with expected args.
 		$client->expects( $this->once() )->method( 'getItem' )->with(
@@ -143,7 +143,7 @@ class TestDBConnector extends TestCase {
 		$client->method( 'waitUntil' )->willReturn( [] );
 
 		// Set client as private property.
-		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
+		$this->set_private_property( $this->connector, 'client', $client );
 
 		// Assert that client's createTable method was called with expected args.
 		$client->expects( $this->once() )->method( 'createTable' )->with(

--- a/tests/php/includes/Snapshots/TestS3StorageConnector.php
+++ b/tests/php/includes/Snapshots/TestS3StorageConnector.php
@@ -81,14 +81,12 @@ class TestS3StorageConnector extends TestCase {
 
 		$this->connector->download_snapshot(
 			'test-id',
+			[ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ],
 			[
 				'contains_db' => true,
 				'contains_files' => false,
 				'project' => 'test-project',
-			],
-			'default',
-			'test-repo',
-			'test-region'
+			]
 		);
 	}
 
@@ -111,14 +109,12 @@ class TestS3StorageConnector extends TestCase {
 
 		$this->connector->download_snapshot(
 			'test-id',
+			[ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ],
 			[
 				'contains_db' => false,
 				'contains_files' => true,
 				'project' => 'test-project',
-			],
-			'default',
-			'test-repo',
-			'test-region'
+			]
 		);
 	}
 
@@ -152,14 +148,12 @@ class TestS3StorageConnector extends TestCase {
 
 		$this->connector->download_snapshot(
 			'test-id',
+			[ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ],
 			[
 				'contains_db' => true,
 				'contains_files' => true,
 				'project' => 'test-project',
-			],
-			'default',
-			'test-repo',
-			'test-region'
+			]
 		);
 	}
 
@@ -180,7 +174,7 @@ class TestS3StorageConnector extends TestCase {
 
 		$this->set_private_property( $this->connector, 'clients', [ 'default_test-region' => $client ] );
 
-		$this->connector->create_bucket( 'default', 'test-repo', 'test-region' );
+		$this->connector->create_bucket( [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ] );
 	}
 
 	/**
@@ -202,13 +196,13 @@ class TestS3StorageConnector extends TestCase {
 		$this->expectException( SnapshotsException::class );
 		$this->expectExceptionMessage( 'S3 bucket already exists.' );
 
-		$this->connector->create_bucket( 'default', 'test-repo', 'test-region' );
+		$this->connector->create_bucket( [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ] );
 
 	}
 
 	/** @covers ::get_client */
 	public function test_get_client_returns_client() {
-		$client = $this->call_private_method( $this->connector, 'get_client', [ 'default', 'test-region' ] );
+		$client = $this->call_private_method( $this->connector, 'get_client', [ [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ] ] );
 
 		$this->assertInstanceOf( S3Client::class, $client );
 	}

--- a/tests/php/includes/Snapshots/TestSnapshotMetaFromFileSystem.php
+++ b/tests/php/includes/Snapshots/TestSnapshotMetaFromFileSystem.php
@@ -97,7 +97,7 @@ class TestSnapshotMetaFromFileSystem extends TestCase {
 
 		$this->set_private_property( $this->meta, 'db', $mock_db );
 
-		$this->assertEquals( [], $this->meta->get_remote( 'test-id', 'default', 'test-repo', 'test-region' ) );
+		$this->assertEquals( [], $this->meta->get_remote( 'test-id', [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ] ) );
 	}
 
 	/** @covers ::get_remote */
@@ -116,7 +116,7 @@ class TestSnapshotMetaFromFileSystem extends TestCase {
 
 		$this->set_private_property( $this->meta, 'db', $mock_db );
 
-		$this->assertEquals( [ 'test' => 'data', 'contains_files' => true, 'contains_db' => true, 'repository' => 'test-repo' ], $this->meta->get_remote( 'test-id', 'default', 'test-repo', 'test-region' ) );
+		$this->assertEquals( [ 'test' => 'data', 'contains_files' => true, 'contains_db' => true, 'repository' => 'test-repo' ], $this->meta->get_remote( 'test-id', [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'test-region', 'role_arn' => '' ] ) );
 	}
 
 	/** @covers ::get_remote */
@@ -135,7 +135,7 @@ class TestSnapshotMetaFromFileSystem extends TestCase {
 
 		$this->set_private_property( $this->meta, 'db', $mock_db );
 
-		$this->assertEquals( [ 'test' => 'data', 'contains_files' => false, 'contains_db' => false, 'repository' => 'test-repo' ], $this->meta->get_remote( 'test-id', 'default', 'test-repo', 'test-region' ) );
+		$this->assertEquals( [ 'test' => 'data', 'contains_files' => false, 'contains_db' => false, 'repository' => 'test-repo' ], $this->meta->get_remote( 'test-id', [ 'profile' =>'default', 'repository' =>'test-repo', 'region' => 'test-region', 'role_arn' => '' ] ) );
 	}
 
 	/** @covers ::generate */

--- a/tests/php/includes/WPCLICommands/TestConfigure.php
+++ b/tests/php/includes/WPCLICommands/TestConfigure.php
@@ -98,6 +98,7 @@ class TestConfigure extends TestCase {
 						'profile' => 'readline4',
 						'user_name' => 'Jane Doe',
 						'user_email' => 'jane.doe@example.com',
+						'role_arn'   => '',
 					]
 				]
 			],
@@ -153,6 +154,7 @@ class TestConfigure extends TestCase {
 					'region' => 'us-east-1',
 					'profile' => 'readline5',
 					'user_name' => 'Jane Doe',
+					'role_arn'   => '',
 					'user_email' => 'jane.doe@example.com',
 				]
 			]
@@ -201,6 +203,7 @@ class TestConfigure extends TestCase {
 			'user_name' => 'Jane Doe',
 			'user_email' => 'jane.doe@example.com',
 			'region' => 'us-east-1',
+			'role_arn' => 'none',
 			'skip_test' => true,
 		];
 	}

--- a/tests/php/includes/WPCLICommands/TestCreateRepository.php
+++ b/tests/php/includes/WPCLICommands/TestCreateRepository.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Tests covering the CreateRepository command class.
- * 
+ *
  * @package TenUp\Snapshots
  */
 
@@ -20,7 +20,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * Class TestCreateRepository
  *
  * @package TenUp\Snapshots\Tests\Commands
- * 
+ *
  * @coversDefaultClass \TenUp\Snapshots\WPCLICommands\CreateRepository
  */
 class TestCreateRepository extends TestCase {
@@ -29,7 +29,7 @@ class TestCreateRepository extends TestCase {
 
 	/**
 	 * CreateRepository instance.
-	 * 
+	 *
 	 * @var CreateRepository
 	 */
 	private $command;
@@ -56,7 +56,7 @@ class TestCreateRepository extends TestCase {
 
 	/**
 	 * Test that the command instance extends WPCLICommand.
-	 * 
+	 *
 	 * @covers ::__construct
 	 */
 	public function test_command_instance() {
@@ -93,7 +93,7 @@ class TestCreateRepository extends TestCase {
 		$storage_connector = $this->createMock( S3StorageConnector::class );
 		$storage_connector->expects( $this->once() )
 			->method( 'create_bucket' )
-			->with( 'default', 'test-repo', 'us-west-1' );
+			->with( [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1', 'role_arn' => '' ] );
 
 		/**
 		 * @var MockObject $db_connector
@@ -101,7 +101,7 @@ class TestCreateRepository extends TestCase {
 		$db_connector = $this->createMock( DynamoDBConnector::class );
 		$db_connector->expects( $this->once() )
 			->method( 'create_tables' )
-			->with( 'default', 'test-repo', 'us-west-1' );
+			->with( [ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1', 'role_arn' => '' ] );
 
 		$this->set_private_property( $this->command, 'storage_connector', $storage_connector );
 		$this->set_private_property( $this->command, 'db_connector', $db_connector );

--- a/tests/php/includes/WPCLICommands/TestDownload.php
+++ b/tests/php/includes/WPCLICommands/TestDownload.php
@@ -169,7 +169,7 @@ class TestDownload extends TestCase {
 	}
 
 	/** @covers ::execute */
-	public function test_execute_dl() {
+	public function test_execute() {
 		$meta = [
 			'project' => 'test-project',
 			'repository' => 'test-repository',

--- a/tests/php/includes/WPCLICommands/TestDownload.php
+++ b/tests/php/includes/WPCLICommands/TestDownload.php
@@ -169,7 +169,7 @@ class TestDownload extends TestCase {
 	}
 
 	/** @covers ::execute */
-	public function test_execute() {
+	public function test_execute_dl() {
 		$meta = [
 			'project' => 'test-project',
 			'repository' => 'test-repository',
@@ -196,10 +196,8 @@ class TestDownload extends TestCase {
 
 		$mock_storage_connector->expects( $this->once() )->method( 'download_snapshot' )->with(
 			'test-id',
-			$meta,
-			'default',
-			'test-repo',
-			'us-west-1'
+			[ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1', 'role_arn' => '' ],
+			$meta
 		);
 
 		add_filter( 'snapshots_readline', function() {

--- a/tests/php/includes/WPCLICommands/TestDownload.php
+++ b/tests/php/includes/WPCLICommands/TestDownload.php
@@ -196,7 +196,7 @@ class TestDownload extends TestCase {
 
 		$mock_storage_connector->expects( $this->once() )->method( 'download_snapshot' )->with(
 			'test-id',
-			[ 'profile' => 'default', 'repository' => 'test-repo', 'region' => 'us-west-1', 'role_arn' => '' ],
+			[ 'profile' => '', 'repository' => 'test-repo', 'region' => 'us-west-1', 'role_arn' => '' ],
 			$meta
 		);
 

--- a/tests/php/includes/WPCLICommands/TestPull.php
+++ b/tests/php/includes/WPCLICommands/TestPull.php
@@ -99,7 +99,6 @@ class TestPull extends TestCase {
 		$snapshot_meta_mock->method( 'get_local' )->willReturn( [] );
 
 		$this->command->set_assoc_args( [ 'repository' => 'test-repository' ] );
-		$this->command->set_assoc_args( [ 'profile' => 'default' ] );
 
 		$this->expectException( SnapshotsException::class );
 		$this->expectExceptionMessage( 'Snapshot does not exist.' );
@@ -107,7 +106,7 @@ class TestPull extends TestCase {
 		$this->set_private_property( $this->command, 'snapshot_meta', $snapshot_meta_mock );
 
 		$snapshot_meta_mock->expects( $this->once() )->method( 'get_remote' )
-			->with( 'test-id', [ 'profile' => 'default', 'repository' => 'test-repository', 'region' => 'us-west-1', 'role_arn' => '' ] );
+			->with( 'test-id', [ 'profile' => '', 'repository' => 'test-repository', 'region' => 'us-west-1', 'role_arn' => '' ] );
 		$snapshot_meta_mock->expects( $this->once() )->method( 'get_local' )
 			->with( 'test-id', 'test-repository' );
 

--- a/tests/php/includes/WPCLICommands/TestPull.php
+++ b/tests/php/includes/WPCLICommands/TestPull.php
@@ -99,6 +99,7 @@ class TestPull extends TestCase {
 		$snapshot_meta_mock->method( 'get_local' )->willReturn( [] );
 
 		$this->command->set_assoc_args( [ 'repository' => 'test-repository' ] );
+		$this->command->set_assoc_args( [ 'profile' => 'default' ] );
 
 		$this->expectException( SnapshotsException::class );
 		$this->expectExceptionMessage( 'Snapshot does not exist.' );
@@ -106,7 +107,7 @@ class TestPull extends TestCase {
 		$this->set_private_property( $this->command, 'snapshot_meta', $snapshot_meta_mock );
 
 		$snapshot_meta_mock->expects( $this->once() )->method( 'get_remote' )
-			->with( 'test-id', 'default', 'test-repository', 'us-west-1' );
+			->with( 'test-id', [ 'profile' => 'default', 'repository' => 'test-repository', 'region' => 'us-west-1', 'role_arn' => '' ] );
 		$snapshot_meta_mock->expects( $this->once() )->method( 'get_local' )
 			->with( 'test-id', 'test-repository' );
 


### PR DESCRIPTION
I'm not familiar enough with the design pattern used here to properly modify the code, so for demo purposes and testing I have created this PR for #47 which contains a hack to get the role_arn value from the wpsnaphots config file to where it needs to be to assume roles.

These changes, in my testing, allow for the original design to work using profiles while also supporting ENV vars and role_arns when present in the config file. What does _not_ work is having credentials hardcoded in the wpsnapshots config file. Adding the ability to load this information from wpsnapshots config would provide backwards compatibility, however.

I tested the following scenarios:

* wpsnapshots configuration contains a valid "roleArn" value and no profile value
* wpsnapshots configuration contains valid "profile" value with hard coded AWS credentials in ~/.aws/credentials
* wpsnapshots configuration with no roleArn or profile and will use the default AWS profile if configured in ~/.aws
* wpsnapshots configuration with no roleArn or profile but with AWS environment variables set
* wpsnapshots has invalid roleArn configured
* also tested against an AWS account with MFA enabled

I did not test this on an ec2 instance with an IAM role assigned but presumably it would work.