### PR TITLE
Fix an issue with the snapshots directory and the command for unzipping the database archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,17 @@ Alternatively, you can download the package as a zip file from the GitHub reposi
 wp package install /path/to/snapshots.zip
 ```
 
-Note: PHP 7.3+ is required.
+#### Windows
+
+Windows users will have to do the following to properly install and use Snapshots:
+
+* LocalWP's WP-CLI version must be 2.8.0+. The current version of LocalWP (7.1.2+6410) includes WP-CLI version 2.7.1. To update it, download the latest version of [wp-cli.phar](https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar) and replace the file in `%USERPROFILE%\AppData\Local\Programs\Local\resources\extraResources\bin\wp-cli\win32`.
+* Install `Gzip` for Windows. Download the desired package from the [GNUWin32 project page](https://gnuwin32.sourceforge.net/packages/gzip.htm) and read the [General Installation Instructions](https://gnuwin32.sourceforge.net/install.html) in order to install the package. **TL;DR** Download the binaries, extract them in a folder, and put that folder into the PATH. After adding the folder into the PATH, restart LocalWP.
+* Install `Grep` for Windows. Download the desired package from the [GNUWin32 project page](https://gnuwin32.sourceforge.net/packages/grep.htm) and read the [General Installation Instructions](https://gnuwin32.sourceforge.net/install.html) in order to install the package. **TL;DR** Download the binaries, extract them in a folder, and put that folder into the PATH. After adding the folder into the PATH, restart LocalWP.
+* Edit the LocalWP site's `wp-config.php` file and change the `DB_HOST` constant in a way to also include the port number, for example `define( 'DB_HOST', 'localhost:10005' );`. Note that this port number occasionally changes, so the value in the `wp-config.php` file has to be up-to-date for the site to be usable. No LocalWP restart is required after changing the port number in the `wp-config.php` file. The port number constant modification can be reverted, `define( 'DB_HOST', 'localhost' );`, after any snapshot-related operation.
+![image](https://github.com/10up/snapshots/assets/1268089/80325a02-e8a0-475a-9d0e-d7540f349716)
+
+**Note**: PHP 7.3+ and WP-CLI 2.8.0+ are required.
 
 ### 2. Authentication
 

--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -138,7 +138,7 @@ class FileSystem implements SharedService {
 
 		if ( is_wp_error( $result ) && 'incompatible_archive' === $result->get_error_code() && strpos( $file, '.sql.gz' ) !== false ) {
 			// Unzip with gzip.
-			$unzip_gzip = sprintf( 'gunzip -c %s > %s', escapeshellarg( $file ), escapeshellarg( snapshots_add_trailing_slash( $destination ) . basename( $file, '.gz' ) ) );
+			$unzip_gzip = sprintf( 'gzip -dkf < %s > %s', escapeshellarg( $file ), escapeshellarg( snapshots_add_trailing_slash( $destination ) . basename( $file, '.gz' ) ) );
 			$result     = exec( $unzip_gzip ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 
 			if ( false === $result ) {

--- a/includes/classes/Snapshots/SnapshotMetaFromFileSystem.php
+++ b/includes/classes/Snapshots/SnapshotMetaFromFileSystem.php
@@ -189,7 +189,7 @@ class SnapshotMetaFromFileSystem extends SnapshotMeta {
 		}
 
 		if ( $args['contains_files'] ) {
-			$meta['files_size'] = $this->snapshot_files->get_file_size( 'files.zip', $id );
+			$meta['files_size'] = $this->snapshot_files->get_file_size( 'files.tar.gz', $id );
 		}
 
 		$this->save_local( $id, $meta );

--- a/includes/classes/SnapshotsDirectory.php
+++ b/includes/classes/SnapshotsDirectory.php
@@ -294,8 +294,12 @@ class SnapshotsDirectory implements SharedService {
 	 */
 	private function get_directory( ?string $id = null ) : string {
 
-		$directory = getenv( 'TENUP_SNAPSHOTS_DIR' );
-		$directory = ! empty( $directory ) ? rtrim( $directory, '/' ) . '/' : rtrim( $_SERVER['HOME'], '/' ) . '/.wpsnapshots/';
+		$directory   = getenv( 'TENUP_SNAPSHOTS_DIR' );
+		$server_home = $_SERVER['HOME'] ?? '';
+		if ( empty( $server_home ) ) {
+			$server_home = str_replace( '\\', '/', $_SERVER['USERPROFILE'] ?? '' );
+		}
+		$directory = ! empty( $directory ) ? rtrim( $directory, '/' ) . '/' : rtrim( $server_home, '/' ) . '/.wpsnapshots/';
 
 		/**
 		 * Filters the wpsnapshots directory.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

In this MR I'm doing Windows-related modifications to make Snapshots running in Windows too. I've also updated the installation instructions in the README.md file with some Windows-related steps.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/snapshots/issues/59

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
* Pull, download, create, push and delete Snapshots from within both a Windows and a Unix machine.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Full Windows installation support


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @gsarig


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
