### PR TITLE
Feature/s3 progress

### DIFF
--- a/includes/classes/FileSystem.php
+++ b/includes/classes/FileSystem.php
@@ -136,6 +136,7 @@ class FileSystem implements SharedService {
 			return;
 		}
 
+		// @phpstan-ignore-next-line
 		if ( is_wp_error( $result ) && 'incompatible_archive' === $result->get_error_code() && strpos( $file, '.sql.gz' ) !== false ) {
 			// Unzip with gzip.
 			$unzip_gzip = sprintf( 'gunzip -c %s > %s', escapeshellarg( $file ), escapeshellarg( snapshots_add_trailing_slash( $destination ) . basename( $file, '.gz' ) ) );

--- a/includes/classes/ProgressBar/ProgressBarInterface.php
+++ b/includes/classes/ProgressBar/ProgressBarInterface.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Progress Bar interface.
+ *
+ * @package TenUp\Snapshots
+ */
+
+namespace TenUp\Snapshots\ProgressBar;
+
+use TenUp\Snapshots\Infrastructure\SharedService;
+
+/**
+ * Progress Bar  interface.
+ *
+ * @package TenUp\Snapshots\ProgressBar
+ */
+interface ProgressBarInterface extends SharedService {
+
+	/**
+	 * Create a progress bar.
+	 *
+	 * @param string $key Key to store the progress bar under.
+	 * @param string $message Message to display.
+	 * @param float  $size Size of the progress bar.
+	 *
+	 * @return mixed
+	 */
+	public function create_progress_bar( string $key, string $message, float $size );
+
+	/**
+	 * Advance the progress bar.
+	 *
+	 * @param string $key Key of the progress bar to progress.
+	 * @param int $amount Amount to advance the progress bar.
+	 *
+	 * @return void
+	 */
+	public function advance_progress_bar( string $key, int $amount = 1 );
+
+	/**
+	 * Finish the progress bar.
+	 *
+	 * @param string $key Key of the progress bar to finish.
+	 *
+	 * @return void
+	 */
+	public function finish_progress_bar( string $key );
+}

--- a/includes/classes/ProgressBar/ProgressBarInterface.php
+++ b/includes/classes/ProgressBar/ProgressBarInterface.php
@@ -31,7 +31,7 @@ interface ProgressBarInterface extends SharedService {
 	 * Advance the progress bar.
 	 *
 	 * @param string $key Key of the progress bar to progress.
-	 * @param int $amount Amount to advance the progress bar.
+	 * @param int    $amount Amount to advance the progress bar.
 	 *
 	 * @return void
 	 */

--- a/includes/classes/ProgressBar/WPCLIProgressBar.php
+++ b/includes/classes/ProgressBar/WPCLIProgressBar.php
@@ -44,7 +44,7 @@ class WPCLIProgressBar implements ProgressBarInterface {
 	 * Advance the progress bar.
 	 *
 	 * @param string $key Key of the progress bar to progress.
-	 * @param int $amount Amount to advance the progress bar.
+	 * @param int    $amount Amount to advance the progress bar.
 	 *
 	 * @return void
 	 */

--- a/includes/classes/ProgressBar/WPCLIProgressBar.php
+++ b/includes/classes/ProgressBar/WPCLIProgressBar.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WP_CLI-based Progress Bar.
+ *
+ * @package TenUp\Snapshots
+ */
+namespace TenUp\Snapshots\ProgressBar;
+
+/**
+ * WP_CLI-based logger.
+ *
+ * @package TenUp\Snapshots\ProgressBar
+ */
+class WPCLIProgressBar implements ProgressBarInterface {
+
+	/**
+	 * The Progress Bar Instances.
+	 *
+	 * @var array
+	 */
+	protected $progress_bars = [];
+
+	/**
+	 * Create a progress bar.
+	 *
+	 * @param string $key Key to store the progress bar under.
+	 * @param string $message Message to display.
+	 * @param float  $size Size of the progress bar.
+	 *
+	 * @return \cli\progress\Bar
+	 */
+	public function create_progress_bar( string $key, string $message, float $size ) {
+		$this->progress_bars[ $key ]['bar'] = \WP_CLI\Utils\make_progress_bar(
+			$message,
+			$size
+		);
+
+		$this->progress_bars[ $key ]['progress'] = 0;
+
+		return $this->progress_bars[ $key ]['bar'];
+	}
+
+	/**
+	 * Advance the progress bar.
+	 *
+	 * @param string $key Key of the progress bar to progress.
+	 * @param int $amount Amount to advance the progress bar.
+	 *
+	 * @return void
+	 */
+	public function advance_progress_bar( string $key, $amount = 1 ) {
+		$this->progress_bars[ $key ]['bar']->tick( $amount - $this->progress_bars[ $key ]['progress'] );
+		$this->progress_bars[ $key ]['progress'] = $amount;
+	}
+
+	/**
+	 * Finish the progress bar.
+	 *
+	 * @param string $key Key of the progress bar to finish.
+	 *
+	 * @return void
+	 */
+	public function finish_progress_bar( string $key ) {
+		$this->progress_bars[ $key ]['bar']->finish();
+		unset( $this->progress_bars[ $key ] );
+	}
+}

--- a/includes/classes/Snapshots.php
+++ b/includes/classes/Snapshots.php
@@ -10,6 +10,7 @@ namespace TenUp\Snapshots;
 use TenUp\Snapshots\Infrastructure\Container;
 use TenUp\Snapshots\Log\WPCLILogger;
 use TenUp\Snapshots\Snapshots\{DynamoDBConnector, FileZipper, S3StorageConnector, SnapshotMetaFromFileSystem};
+use TenUp\Snapshots\ProgressBar\WPCLIProgressBar;
 use TenUp\Snapshots\WordPress\Database;
 use TenUp\Snapshots\WPCLI\Prompt;
 use TenUp\Snapshots\WPCLICommands\{Configure, Create, CreateRepository, Delete, Download, Pull, Push, Search};
@@ -76,6 +77,7 @@ final class Snapshots extends Container {
 			'wp_snapshots_config/wp_snapshots_config' => SnapshotsConfigFromFileSystem::class,
 			'wpcli/prompt'                            => Prompt::class,
 			'wpcli/url_replacer_factory'              => URLReplacerFactory::class,
+			'snapshots/progress_bar'                  => WPCLIProgressBar::class,
 		];
 
 		/**

--- a/includes/classes/Snapshots/S3StorageConnector.php
+++ b/includes/classes/Snapshots/S3StorageConnector.php
@@ -84,10 +84,10 @@ class S3StorageConnector implements StorageConnectorInterface {
 					'Key'    => $snapshot_meta['project'] . '/' . $id . '/data.sql.gz',
 					'SaveAs' => $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ),
 					'@http' => [
-						'progress' => function ( $expectedDl, $dl ) {
+						'progress' => function ( $expected_dl, $dl ) {
 							$this->progress_bar->advance_progress_bar( 'db_dl', (int) $dl );
-						}
-					]
+						},
+					],
 				]
 			);
 
@@ -107,10 +107,10 @@ class S3StorageConnector implements StorageConnectorInterface {
 					'Key'    => $snapshot_meta['project'] . '/' . $id . '/files.tar.gz',
 					'SaveAs' => $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ),
 					'@http' => [
-						'progress' => function ( $expectedDl, $dl ) {
+						'progress' => function ( $expected_dl, $dl ) {
 							$this->progress_bar->advance_progress_bar( 'files_dl', (int) $dl );
-						}
-					]
+						},
+					],
 				]
 			);
 
@@ -178,10 +178,10 @@ class S3StorageConnector implements StorageConnectorInterface {
 					'SourceFile' => realpath( $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ) ),
 					'ContentMD5' => base64_encode( md5_file( $this->snapshots_file_system->get_file_path( 'data.sql.gz', $id ), true ) ), // phpcs:ignore
 					'@http' => [
-						'progress' => function ( $expectedDl, $dl, $expectedUl, $ul ) {
+						'progress' => function ( $expected_dl, $dl, $expected_ul, $ul ) {
 							$this->progress_bar->advance_progress_bar( 'db_ul', (int) $ul );
-						}
-					]
+						},
+					],
 				]
 			);
 
@@ -203,10 +203,10 @@ class S3StorageConnector implements StorageConnectorInterface {
 					'SourceFile' => realpath( $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ) ),
 					'ContentMD5' => base64_encode( md5_file( $this->snapshots_file_system->get_file_path( 'files.tar.gz', $id ), true ) ), // phpcs:ignore
 					'@http' => [
-						'progress' => function ( $expectedDl, $dl, $expectedUl, $ul ) {
+						'progress' => function ( $expected_dl, $dl, $expected_ul, $ul ) {
 							$this->progress_bar->advance_progress_bar( 'files_ul', (int) $ul );
-						}
-					]
+						},
+					],
 				]
 			);
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,7 @@ parameters:
 	excludePaths:
 		- %currentWorkingDirectory%/includes/lib/wp-file-system-direct-shim.php
 	ignoreErrors:
+		- '#Function WP_CLI\\Utils\\make_progress_bar not found.#'
 	earlyTerminatingMethodCalls:
 		\WP_CLI:
 			- WP_CLI::error


### PR DESCRIPTION
### Description of the Change
This PR adds progress bars to S3 uploads and downloads. 

Once issue I've heard a lot internally with Snapshots (and WP Snapshots) is that there is no feedback when uploading or downloading a snapshot. This is a particular issue when the snapshot is of a significant size, as the engineer has no idea of progress.

This PR introduces a new ProgressBar system that utilises the WP-CLI Progress Bar. This will render a bar when uploading or downloading files, letting the engineers know that the process hasn't stalled and giving a rough timeframe for the process to finish.

Example of this working during upload:
<img width="1504" alt="image" src="https://github.com/10up/snapshots/assets/968731/f3c14314-c575-486d-870f-4f00f3d4921a">

Example of this working during a download:
![iTerm - darylldoyle@MacBook-Pro-2-~ 2023-11-22 at 12 44 03 PM](https://github.com/10up/snapshots/assets/968731/526b6aea-28c2-4c58-9a3d-45e3650e5244)


### How to test the Change
Checkout this branch and try pushing/pulling snapshots.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Progress bars when uploading and downloading snapshots.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
